### PR TITLE
Reformat 'about' documentation for nextercism

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -5,3 +5,5 @@ The most common form of Python is compiled in C. This is often invisible to the 
 [Python is used extensively](https://www.python.org/about/apps/) in scientific computing, finance, games, networking, internet development, and in assembling pipelines of other programs.
 
 Python was started by Guido van Rossum in 1989. Its name is an homage to the comedy troupe Monty Python. Python 2 is used widely but support may end by 2020. Python 3 was introduced in 2008 and is beginning to be adopted more widely. They are similar, but users will encounter [some differences](http://blog.teamtreehouse.com/python-2-vs-python-3). Python development is shepherded by [The Python Software Foundation](https://www.python.org/about/) and there are active community-based user groups worldwide.
+
+Foobar

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -7,3 +7,4 @@ The most common form of Python is compiled in C. This is often invisible to the 
 Python was started by Guido van Rossum in 1989. Its name is an homage to the comedy troupe Monty Python. Python 2 is used widely but support may end by 2020. Python 3 was introduced in 2008 and is beginning to be adopted more widely. They are similar, but users will encounter [some differences](http://blog.teamtreehouse.com/python-2-vs-python-3). Python development is shepherded by [The Python Software Foundation](https://www.python.org/about/) and there are active community-based user groups worldwide.
 
 Foobar
+Barfoo


### PR DESCRIPTION
Hello. I'm trying to get all of the ABOUT.md files reformatted to fit with the new look and feel of nextercism. This means removing things like line-breaks and markdown that we're not supporting.

As an example from the C++ Track, we've gone from:
<img width=1167 alt=screen