### PR TITLE
Reformat 'about' documentation for nextercism

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -5,3 +5,5 @@ The most common form of Python is compiled in C. This is often invisible to the 
 [Python is used extensively](https://www.python.org/about/apps/) in scientific computing, finance, games, networking, internet development, and in assembling pipelines of other programs.
 
 Python was started by Guido van Rossum in 1989. Its name is an homage to the comedy troupe Monty Python. Python 2 is used widely but support may end by 2020. Python 3 was introduced in 2008 and is beginning to be adopted more widely. They are similar, but users will encounter [some differences](http://blog.teamtreehouse.com/python-2-vs-python-3). Python development is shepherded by [The Python Software Foundation](https://www.python.org/about/) and there are active community-based user groups worldwide.
+
+Foobar

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -7,3 +7,4 @@ The most common form of Python is compiled in C. This is often invisible to the 
 Python was started by Guido van Rossum in 1989. Its name is an homage to the comedy troupe Monty Python. Python 2 is used widely but support may end by 2020. Python 3 was introduced in 2008 and is beginning to be adopted more widely. They are similar, but users will encounter [some differences](http://blog.teamtreehouse.com/python-2-vs-python-3). Python development is shepherded by [The Python Software Foundation](https://www.python.org/about/) and there are active community-based user groups worldwide.
 
 Foobar
+Barfoo


### PR DESCRIPTION
Hello. I'm trying to get all of the ABOUT.md files reformatted to fit with the new look and feel of nextercism. This means removing things like line-breaks and markdown that we're not supporting.

As an example from the C++ Track, we've gone from:
<img width="1167" alt="screen shot 2017-08-06 at 15 16 34" src="https://user-images.githubusercontent.com/286476/29004482-b990fad8-7abf-11e7-98c5-cc3f2f1ee3e8.png">
to:
<img width="1161" alt="screen shot 2017-08-06 at 15 15 43" src="https://user-images.githubusercontent.com/286476/29004485-c26acf6c-7abf-11e7-90f1-575b2edd5316.png">

As a general note, after these formatting changes get merged, we're hoping that track
maintainers will take some time to review the contents of the ABOUT.md file and edit
it to make it a bit shorter and more casual. We're looking for less wikipedia and more
of an enthusiastic and friendly pitch that you might make to a friend over a drink for
why they should try the language.

For some examples of tracks where I think they've done this well take a look at the
Go and R tracks:
- https://github.com/exercism/go/blob/master/docs/ABOUT.md
- https://github.com/exercism/r/blob/3f05539d19d7e20d2a9d5cd2cecd3dc56f4f23e8/docs/ABOUT.md

Thank you!